### PR TITLE
Add Access Control to wager contract

### DIFF
--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -29,12 +29,14 @@ fn test_set_escrow_address_fail() {
 
 #[test]
 fn test_set_escrow_address() {
-    let (wager, contract_address) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, contract_address) = deploy_wager(admin_address);
     let mut spy = spy_events();
 
     let new_address = contract_address_const::<'new_address'>();
-
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(new_address);
+    stop_cheat_caller_address(wager.contract_address);
     spy
         .assert_emitted(
             @array![
@@ -60,25 +62,33 @@ fn test_set_escrow_address() {
 #[test]
 #[should_panic(expected: ('Invalid address',))]
 fn test_set_escrow_address_zero_address_fails() {
-    let (wager, _) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, _) = deploy_wager(admin_address);
     let zero_address: ContractAddress = contract_address_const::<0>();
 
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(zero_address);
+    stop_cheat_caller_address(wager.contract_address);
 }
 
 #[test]
 fn test_get_escrow_address() {
-    let (wager, _) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, _) = deploy_wager(admin_address);
     let first_address = contract_address_const::<'new_address'>();
 
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(first_address);
+    stop_cheat_caller_address(wager.contract_address);
     let initial_address: ContractAddress = wager.get_escrow_address();
 
     // Check if the initial address is as expected
     assert!(initial_address == first_address, "Initial escrow address is not being returned");
 
     let second_address = contract_address_const::<'second_address'>();
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(second_address);
+    stop_cheat_caller_address(wager.contract_address);
     let final_address: ContractAddress = wager.get_escrow_address();
 
     // Check if the updated address is as expected
@@ -87,27 +97,29 @@ fn test_get_escrow_address() {
 
 #[test]
 fn test_create_wager_success() {
-    create_wager(3000, 2000);
+    let admin_address = ADMIN();
+    create_wager(3000, 2000, admin_address);
 }
 
 #[test]
 #[should_panic(expected: 'Insufficient balance')]
 fn test_create_wager_insufficient_balance() {
-    create_wager(2000, 2200);
+    let admin_address = ADMIN();
+    create_wager(2000, 2200, admin_address);
 }
 
 #[test]
 fn test_fund_wallet_success() {
     // Deploy contracts
-    let (wager, wager_address) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, wager_address) = deploy_wager(admin_address);
     let (escrow, strk_dispatcher) = deploy_escrow(wager_address);
-
     // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(escrow.contract_address);
-
+    stop_cheat_caller_address(wager.contract_address);
     let amount = 50_u256;
     let owner = OWNER();
-
     // Approve tokens from OWNER for escrow
     start_cheat_caller_address(strk_dispatcher.contract_address, owner);
     strk_dispatcher.approve(escrow.contract_address, amount);
@@ -123,7 +135,8 @@ fn test_fund_wallet_success() {
 #[should_panic(expected: ('Escrow not configured',))]
 fn test_fund_wallet_no_escrow() {
     // Deploy wager without setting escrow
-    let (wager, _) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, _) = deploy_wager(admin_address);
 
     // Try to fund wallet without escrow configured
     wager.fund_wallet(100_u256);
@@ -132,13 +145,16 @@ fn test_fund_wallet_no_escrow() {
 #[test]
 #[should_panic(expected: ('Amount must be positive',))]
 fn test_fund_wallet_zero_amount() {
-    let (wager, wager_address) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, wager_address) = deploy_wager(admin_address);
 
     // Deploy escrow - using the correct signature without arguments
     let (escrow, strk_dispatcher) = deploy_escrow(wager_address);
 
     // Set escrow address
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
 
     // Test with zero amount - should panic
     wager.fund_wallet(0_u256);
@@ -147,10 +163,13 @@ fn test_fund_wallet_zero_amount() {
 #[test]
 #[should_panic(expected: ('ERC20: insufficient allowance',))]
 fn test_fund_wallet_without_approval() {
-    let (wager, wager_address) = deploy_wager();
+    let admin_address = ADMIN();
+    let (wager, wager_address) = deploy_wager(admin_address);
     let (escrow, strk_dispatcher) = deploy_escrow(wager_address);
 
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
 
     // Try to fund without any token approval
     start_cheat_caller_address(wager.contract_address, OWNER());

--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -5,13 +5,27 @@ use contracts::wager::wager::StrkWager;
 
 use contracts::wager::interface::{IStrkWagerDispatcher, IStrkWagerDispatcherTrait};
 use contracts::escrow::interface::IEscrowDispatcherTrait;
-use contracts::tests::utils::{deploy_wager, create_wager, deploy_mock_erc20, deploy_escrow, OWNER};
+use contracts::tests::utils::{
+    deploy_wager, create_wager, deploy_mock_erc20, deploy_escrow, OWNER, ADMIN
+};
 use openzeppelin::token::erc20::interface::IERC20DispatcherTrait;
 
 use snforge_std::{
     declare, ContractClassTrait, DeclareResultTrait, start_cheat_caller_address,
     stop_cheat_caller_address, spy_events, EventSpyAssertionsTrait
 };
+
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_escrow_address_fail() {
+    let admin_address = ADMIN();
+    let new_address = contract_address_const::<'new_address'>();
+    let (wager, contract_address) = deploy_wager(admin_address);
+    start_cheat_caller_address(contract_address, new_address);
+    wager.set_escrow_address(new_address);
+    stop_cheat_caller_address(contract_address);
+}
 
 #[test]
 fn test_set_escrow_address() {

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -17,6 +17,10 @@ pub fn OWNER() -> ContractAddress {
     'owner'.try_into().unwrap()
 }
 
+pub fn ADMIN() -> ContractAddress {
+    'admin'.try_into().unwrap()
+}
+
 pub fn WAGER_ADDRESS() -> ContractAddress {
     'wager'.try_into().unwrap()
 }
@@ -48,9 +52,10 @@ pub fn deploy_escrow(wager_address: ContractAddress) -> (IEscrowDispatcher, IERC
     (IEscrowDispatcher { contract_address }, strk_dispatcher)
 }
 
-pub fn deploy_wager() -> (IStrkWagerDispatcher, ContractAddress) {
+pub fn deploy_wager(admin_address: ContractAddress) -> (IStrkWagerDispatcher, ContractAddress) {
     let contract = declare("StrkWager").unwrap().contract_class();
     let mut calldata = array![];
+    admin_address.serialize(ref calldata);
 
     let (contract_address, _) = contract.deploy(@calldata).unwrap();
     let dispatcher = IStrkWagerDispatcher { contract_address };
@@ -58,13 +63,15 @@ pub fn deploy_wager() -> (IStrkWagerDispatcher, ContractAddress) {
     (dispatcher, contract_address)
 }
 
-pub fn create_wager(deposit: u256, stake: u256) {
-    let (wager, wager_contract) = deploy_wager();
+pub fn create_wager(deposit: u256, stake: u256, admin_address: ContractAddress) {
+    let (wager, wager_contract) = deploy_wager(admin_address);
     let (escrow, strk_dispatcher) = deploy_escrow(wager_contract);
     let creator = OWNER();
     let mut spy = spy_events();
 
+    start_cheat_caller_address(wager.contract_address, admin_address);
     wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
 
     cheat_caller_address(strk_dispatcher.contract_address, creator, CheatSpan::TargetCalls(1));
     strk_dispatcher.approve(escrow.contract_address, deposit);


### PR DESCRIPTION
closes #21 
integration OpenZeppelin access control into the wager contract

updates:

* Modified the constructor to initialize the `AccessControlComponent` and grant the `ADMIN_ROLE` to a specified admin_contract.
* Added a constant `ADMIN_ROLE` to uniquely identify the admin role.
* Updated the `set_escrow_address` method, allowing only the admin to set the escrow address.
* `utils` and `test_wager` were refactored to provide admin_address in the wager contract's constructor

![image](https://github.com/user-attachments/assets/fdb7d7e8-eac8-4c20-a9a8-147a7f0b5509)
