### PR TITLE
Issue #72 Implement _has_sufficient_balance Function

### DIFF
--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -220,14 +220,21 @@ fn test_join_wager_success_with_in_app_wallet_balance() {
     let stake = 100_u256;
     let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
 
-    // Approve tokens from OWNER for escrow
     let owner = OWNER();
-    start_cheat_caller_address(strk_dispatcher.contract_address, owner);
+    let bob = BOB();
+
+    // Mint tokens for BOB
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(bob, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+    
+    // BOB approves tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, bob);
     strk_dispatcher.approve(escrow.contract_address, stake);
     stop_cheat_caller_address(strk_dispatcher.contract_address);
 
     // Fund the wallet of the participant
-    start_cheat_caller_address(wager.contract_address, owner);
+    start_cheat_caller_address(wager.contract_address, bob);
     wager.fund_wallet(stake);
     stop_cheat_caller_address(wager.contract_address);
 
@@ -275,15 +282,22 @@ fn test_join_wager_success_with_external_wallet_balance() {
     let deposit = stake - 10;
     let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
 
-    // Approve tokens from OWNER for escrow
     let owner = OWNER();
-    start_cheat_caller_address(strk_dispatcher.contract_address, owner);
+    let bob = BOB();
+
+    // Mint tokens for BOB 
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(bob, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+    
+    // BOB approves tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, bob);
     strk_dispatcher.approve(escrow.contract_address, stake);
     stop_cheat_caller_address(strk_dispatcher.contract_address);
 
-    // Fund the wallet of the participant
-    start_cheat_caller_address(wager.contract_address, owner);
-    wager.fund_wallet(stake);
+    // Fund the in-app wallet of the participant (not enough)
+    start_cheat_caller_address(wager.contract_address, bob);
+    wager.fund_wallet(deposit);
     stop_cheat_caller_address(wager.contract_address);
 
     // Join the wager

--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -227,7 +227,7 @@ fn test_join_wager_success_with_in_app_wallet_balance() {
     start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
     strk_dispatcher.transfer(bob, stake);
     stop_cheat_caller_address(strk_dispatcher.contract_address);
-    
+
     // BOB approves tokens
     start_cheat_caller_address(strk_dispatcher.contract_address, bob);
     strk_dispatcher.approve(escrow.contract_address, stake);
@@ -285,11 +285,11 @@ fn test_join_wager_success_with_external_wallet_balance() {
     let owner = OWNER();
     let bob = BOB();
 
-    // Mint tokens for BOB 
+    // Mint tokens for BOB
     start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
     strk_dispatcher.transfer(bob, stake);
     stop_cheat_caller_address(strk_dispatcher.contract_address);
-    
+
     // BOB approves tokens
     start_cheat_caller_address(strk_dispatcher.contract_address, bob);
     strk_dispatcher.approve(escrow.contract_address, stake);

--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -117,7 +117,8 @@ fn test_create_wager_success_with_external_wallet_balance() {
     start_cheat_caller_address(wager.contract_address, ADMIN());
     wager.set_escrow_address(escrow.contract_address);
     stop_cheat_caller_address(wager.contract_address);
-    // user have less deposite than required for stake, but still has enough balance on his external wallet
+    // user have less deposite than required for stake, but still has enough balance on his external
+    // wallet
     create_wager(wager, escrow, strk_dispatcher, 2000, 2200);
 }
 
@@ -132,10 +133,11 @@ fn test_create_wager_insufficient_balance() {
     start_cheat_caller_address(wager.contract_address, ADMIN());
     wager.set_escrow_address(escrow.contract_address);
     stop_cheat_caller_address(wager.contract_address);
-    
+
     // transfer all funds to another account so OWNER has inssuficient balance on external wallet
     start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
-    strk_dispatcher.transfer(contract_address_const::<'any-address'>(), strk_dispatcher.balance_of(OWNER()));
+    strk_dispatcher
+        .transfer(contract_address_const::<'any-address'>(), strk_dispatcher.balance_of(OWNER()));
     stop_cheat_caller_address(strk_dispatcher.contract_address);
 
     create_wager(wager, escrow, strk_dispatcher, 2000, 2200);
@@ -270,7 +272,7 @@ fn test_join_wager_success_with_external_wallet_balance() {
 
     // Create a wager
     let stake = 100_u256;
-    let deposit = stake-10;
+    let deposit = stake - 10;
     let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
 
     // Approve tokens from OWNER for escrow
@@ -334,7 +336,7 @@ fn test_join_wager_insufficient_balance() {
     strk_dispatcher.transfer(bob, deposit);
     stop_cheat_caller_address(strk_dispatcher.contract_address);
 
-    // BOB approves tokens 
+    // BOB approves tokens
     start_cheat_caller_address(strk_dispatcher.contract_address, bob);
     strk_dispatcher.approve(escrow.contract_address, deposit);
     stop_cheat_caller_address(strk_dispatcher.contract_address);

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -55,7 +55,10 @@ pub fn deploy_escrow(wager_address: ContractAddress) -> (IEscrowDispatcher, IERC
 pub fn deploy_wager(admin_address: ContractAddress) -> (IStrkWagerDispatcher, ContractAddress) {
     let contract = declare("StrkWager").unwrap().contract_class();
     let mut calldata = array![];
+    let strk_dispatcher = deploy_mock_erc20();
+    let strk_address = strk_dispatcher.contract_address;
     admin_address.serialize(ref calldata);
+    strk_address.serialize(ref calldata);
 
     let (contract_address, _) = contract.deploy(@calldata).unwrap();
     let dispatcher = IStrkWagerDispatcher { contract_address };

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -39,7 +39,9 @@ pub fn deploy_mock_erc20() -> IERC20Dispatcher {
     IERC20Dispatcher { contract_address }
 }
 
-pub fn deploy_escrow(wager_address: ContractAddress, strk_dispatcher:IERC20Dispatcher) -> (IEscrowDispatcher, IERC20Dispatcher) {
+pub fn deploy_escrow(
+    wager_address: ContractAddress, strk_dispatcher: IERC20Dispatcher
+) -> (IEscrowDispatcher, IERC20Dispatcher) {
     let contract = declare("Escrow").unwrap().contract_class();
 
     let mut calldata = array![];
@@ -51,7 +53,9 @@ pub fn deploy_escrow(wager_address: ContractAddress, strk_dispatcher:IERC20Dispa
     (IEscrowDispatcher { contract_address }, strk_dispatcher)
 }
 
-pub fn deploy_wager(admin_address: ContractAddress, strk_dispatcher:IERC20Dispatcher) -> (IStrkWagerDispatcher, ContractAddress) {
+pub fn deploy_wager(
+    admin_address: ContractAddress, strk_dispatcher: IERC20Dispatcher
+) -> (IStrkWagerDispatcher, ContractAddress) {
     let contract = declare("StrkWager").unwrap().contract_class();
     let mut calldata = array![];
     let strk_address = strk_dispatcher.contract_address;

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -39,9 +39,8 @@ pub fn deploy_mock_erc20() -> IERC20Dispatcher {
     IERC20Dispatcher { contract_address }
 }
 
-pub fn deploy_escrow(wager_address: ContractAddress) -> (IEscrowDispatcher, IERC20Dispatcher) {
+pub fn deploy_escrow(wager_address: ContractAddress, strk_dispatcher:IERC20Dispatcher) -> (IEscrowDispatcher, IERC20Dispatcher) {
     let contract = declare("Escrow").unwrap().contract_class();
-    let strk_dispatcher = deploy_mock_erc20();
 
     let mut calldata = array![];
     strk_dispatcher.serialize(ref calldata);
@@ -52,10 +51,9 @@ pub fn deploy_escrow(wager_address: ContractAddress) -> (IEscrowDispatcher, IERC
     (IEscrowDispatcher { contract_address }, strk_dispatcher)
 }
 
-pub fn deploy_wager(admin_address: ContractAddress) -> (IStrkWagerDispatcher, ContractAddress) {
+pub fn deploy_wager(admin_address: ContractAddress, strk_dispatcher:IERC20Dispatcher) -> (IStrkWagerDispatcher, ContractAddress) {
     let contract = declare("StrkWager").unwrap().contract_class();
     let mut calldata = array![];
-    let strk_dispatcher = deploy_mock_erc20();
     let strk_address = strk_dispatcher.contract_address;
     admin_address.serialize(ref calldata);
     strk_address.serialize(ref calldata);
@@ -67,8 +65,10 @@ pub fn deploy_wager(admin_address: ContractAddress) -> (IStrkWagerDispatcher, Co
 }
 
 pub fn setup() -> (IStrkWagerDispatcher, IEscrowDispatcher, IERC20Dispatcher) {
-    let (wager, wager_contract) = deploy_wager(ADMIN());
-    let (escrow, strk_dispatcher) = deploy_escrow(wager_contract);
+    let strk_dispatcher = deploy_mock_erc20();
+
+    let (wager, wager_contract) = deploy_wager(ADMIN(), strk_dispatcher);
+    let (escrow, strk_dispatcher) = deploy_escrow(wager_contract, strk_dispatcher);
 
     (wager, escrow, strk_dispatcher)
 }

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -218,12 +218,8 @@ pub mod StrkWager {
     #[generate_trait]
     pub impl InternalFunctions of InternalFunctionsTrait {
         fn _has_sufficient_balance(self: @ContractState, stake: u256) -> bool {
-            let caller = get_caller_address();
-            // Evaluating in-app wallet balance
-            let escrow_dispatcher = IEscrowDispatcher {
-                contract_address: self.escrow_address.read()
-            };
-            let in_app_balance = escrow_dispatcher.get_balance(caller);
+            let caller = get_caller_address(); 
+            let in_app_balance = self.get_balance(caller);
             if in_app_balance >= stake {
                 return true;
             }

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -218,7 +218,7 @@ pub mod StrkWager {
     #[generate_trait]
     pub impl InternalFunctions of InternalFunctionsTrait {
         fn _has_sufficient_balance(self: @ContractState, stake: u256) -> bool {
-            let caller = get_caller_address(); 
+            let caller = get_caller_address();
             let in_app_balance = self.get_balance(caller);
             if in_app_balance >= stake {
                 return true;

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -80,7 +80,9 @@ pub mod StrkWager {
 
 
     #[constructor]
-    fn constructor(ref self: ContractState, admin_contract: ContractAddress, strk_address: ContractAddress) {
+    fn constructor(
+        ref self: ContractState, admin_contract: ContractAddress, strk_address: ContractAddress
+    ) {
         self.accesscontrol.initializer();
         self.accesscontrol._grant_role(ADMIN_ROLE, admin_contract);
         self.strk_address.write(strk_address);
@@ -125,7 +127,7 @@ pub mod StrkWager {
             mode: Mode
         ) -> u64 {
             assert(self._has_sufficient_balance(stake), 'Insufficient balance');
-            
+
             let creator = get_caller_address();
             let wager_id = self.wager_count.read() + 1;
 
@@ -159,7 +161,7 @@ pub mod StrkWager {
             assert(!wager.creator.is_zero(), 'Wager does not exist');
             assert(!wager.resolved, 'Wager is already resolved');
             assert(self._has_sufficient_balance(wager.stake), 'Insufficient balance');
-            
+
             let caller = get_caller_address();
 
             let participant_id = self.wager_participants_count.entry(wager_id).read() + 1;
@@ -215,15 +217,17 @@ pub mod StrkWager {
 
     #[generate_trait]
     pub impl InternalFunctions of InternalFunctionsTrait {
-        fn _has_sufficient_balance(self: @ContractState, stake:u256) -> bool {
+        fn _has_sufficient_balance(self: @ContractState, stake: u256) -> bool {
             let caller = get_caller_address();
             // Evaluating in-app wallet balance
-            let escrow_dispatcher = IEscrowDispatcher { contract_address: self.escrow_address.read() };
+            let escrow_dispatcher = IEscrowDispatcher {
+                contract_address: self.escrow_address.read()
+            };
             let in_app_balance = escrow_dispatcher.get_balance(caller);
             if in_app_balance >= stake {
                 return true;
             }
-            
+
             // Evaluating external wallet balance
             let strk_dispatcher = IERC20Dispatcher { contract_address: self.strk_address.read() };
             let external_balance = strk_dispatcher.balance_of(caller);


### PR DESCRIPTION
### Changes implemented:
- Create a function _has_sufficient_balance that evaluates if caller address has a balance greater or equal than the stake amount. Either on the in-app wallet or a external wallet (i.e -> ArgentX). 
- Implement the created function _has_sufficient_balance on the contract functions create_wager and join_wager. And put such assertion on the top to reduce gas prices on failure cases (when has no enough balance). 

### Finally I modified test suites as follows:
- Rename test_create_wager_success to test_create_wager_success_with_in_app_wallet_balance. 
- Create new test case test_create_wager_success_external_wallet_balance.
- Modify test_create_wager_insufficient_balance to call create_wallet function from a account without enough balance on in-app or external address.
- Rename test_join_wager_success to test_join_wager_success_with_in_app_wallet_balance. 
- Create new test case test_join_wager_success_with_external_wallet_balance
-  The test case test_join_wager_insufficient_balance was written in a way that match perfect with the new requirements. It was not needed modify it to much. BUT has a error when call create_wager function, it was passing the same value for deposit and stake params instead of passing a smaller amount for deposit. Already fixed.  


I'm attentive to any correction 🦅