### PR TITLE
feat: secure head-to-head wager

### DIFF
--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -25,6 +25,10 @@ pub fn WAGER_ADDRESS() -> ContractAddress {
     'wager'.try_into().unwrap()
 }
 
+pub fn ALICE() -> ContractAddress {
+    'alice'.try_into().unwrap()
+}
+
 pub fn BOB() -> ContractAddress {
     'bob'.try_into().unwrap()
 }

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -167,6 +167,12 @@ pub mod StrkWager {
 
             assert(!wager.creator.is_zero(), 'Wager does not exist');
             assert(!wager.resolved, 'Wager is already resolved');
+            if wager.mode == Mode::HeadToHead {
+                assert(
+                    self.wager_participants_count.entry(wager_id).read() == 1,
+                    'Wager has 2 participants'
+                );
+            }
             assert(self._has_sufficient_balance(wager.stake), 'Insufficient balance');
 
             let caller = get_caller_address();


### PR DESCRIPTION
## Changes
- Updated `join_wager` function to restrict entry of more than 2 users in a `HeadToHead` wager.
- Unit test added to ensure not more than 2 participants can join a `HeadToHead` wager.
- Closes #77 

## Tests Screenshot 
![image](https://github.com/user-attachments/assets/ee31985c-3a1c-4a20-999f-c402a16446c8)
