### PR TITLE
Feat: Implement wager participant claim functionality

### DIFF
--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 use starknet::{testing, contract_address_const, get_caller_address};
 
 use contracts::wager::wager::StrkWager;
-use contracts::wager::types::{Category, Mode};
+use contracts::wager::types::{Category, Mode, Claim};
 use contracts::wager::interface::{IStrkWagerDispatcher, IStrkWagerDispatcherTrait};
 use contracts::escrow::interface::IEscrowDispatcherTrait;
 use contracts::tests::utils::{OWNER, ADMIN, ALICE, BOB, setup, create_wager};
@@ -218,6 +218,7 @@ fn test_join_wager_success_with_in_app_wallet_balance() {
 
     // Create a wager
     let stake = 100_u256;
+    let claim = Claim::Yes;
     let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
 
     let owner = OWNER();
@@ -240,7 +241,7 @@ fn test_join_wager_success_with_in_app_wallet_balance() {
 
     // Join the wager
     start_cheat_caller_address(wager.contract_address, owner);
-    wager.join_wager(wager_id);
+    wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 
     let participants = wager.get_wager_participants(wager_id);
@@ -284,6 +285,7 @@ fn test_join_wager_success_with_external_wallet_balance() {
 
     let owner = OWNER();
     let bob = BOB();
+    let claim = Claim::No;
 
     // Mint tokens for BOB
     start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
@@ -302,7 +304,7 @@ fn test_join_wager_success_with_external_wallet_balance() {
 
     // Join the wager
     start_cheat_caller_address(wager.contract_address, owner);
-    wager.join_wager(wager_id);
+    wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 
     let participants = wager.get_wager_participants(wager_id);
@@ -334,6 +336,7 @@ fn test_join_wager_insufficient_balance() {
     // Deploy contracts
     let (wager, escrow, strk_dispatcher) = setup();
     let bob = BOB();
+    let claim = Claim::No;
 
     // Configure wager with escrow
     start_cheat_caller_address(wager.contract_address, ADMIN());
@@ -360,7 +363,7 @@ fn test_join_wager_insufficient_balance() {
     wager.fund_wallet(deposit);
 
     // Attempt to join the wager (should panic)
-    wager.join_wager(wager_id);
+    wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 }
 
@@ -369,6 +372,7 @@ fn test_join_wager_insufficient_balance() {
 #[should_panic(expected: ('Wager is already resolved',))]
 fn test_join_wager_resolved() {
     let (wager, escrow, strk_dispatcher) = setup();
+    let claim = Claim::No;
 
     // Configure wager with escrow
     start_cheat_caller_address(wager.contract_address, ADMIN());
@@ -384,7 +388,7 @@ fn test_join_wager_resolved() {
     wager.resolve_wager(wager_id, owner);
 
     start_cheat_caller_address(wager.contract_address, owner);
-    wager.join_wager(wager_id);
+    wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 }
 
@@ -455,6 +459,7 @@ fn test_join_wager_head_to_head_full() {
     let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
 
     let bob = BOB();
+    let claim = Claim::No;
     // Mint tokens for BOB and approve
     start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
     strk_dispatcher.transfer(bob, stake);
@@ -467,7 +472,7 @@ fn test_join_wager_head_to_head_full() {
 
     start_cheat_caller_address(wager.contract_address, bob);
     wager.fund_wallet(stake);
-    wager.join_wager(wager_id);
+    wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 
     // Try to join with a third participant - should fail
@@ -483,7 +488,7 @@ fn test_join_wager_head_to_head_full() {
 
     start_cheat_caller_address(wager.contract_address, alice);
     wager.fund_wallet(stake);
-    wager.join_wager(wager_id); // Should panic here
+    wager.join_wager(wager_id, claim); // Should panic here
     stop_cheat_caller_address(wager.contract_address);
 }
 
@@ -501,6 +506,7 @@ fn test_is_wager_participant() {
     // Create a wager
     let stake = 100_u256;
     let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
+    let claim = Claim::No;
 
     let owner = OWNER();
     let bob = BOB();
@@ -522,7 +528,7 @@ fn test_is_wager_participant() {
 
     // Join the wager
     start_cheat_caller_address(wager.contract_address, bob);
-    wager.join_wager(wager_id);
+    wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 
     assert(wager.is_wager_participant(wager_id, owner), 'owner is a participant');

--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -535,3 +535,104 @@ fn test_is_wager_participant() {
     assert(wager.is_wager_participant(wager_id, bob), 'bob is a participant');
     assert(!wager.is_wager_participant(wager_id, ALICE()), 'alice is non participant');
 }
+
+#[test]
+fn test_join_wager_with_claim() {
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Create a wager
+    let stake = 100_u256;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
+    let claim = Claim::No;
+
+    let owner = OWNER();
+    let bob = BOB();
+    // Mint tokens for BOB
+    start_cheat_caller_address(strk_dispatcher.contract_address, owner);
+    strk_dispatcher.transfer(bob, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // BOB approves tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, bob);
+    strk_dispatcher.approve(escrow.contract_address, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Fund the wallet of the participant
+    start_cheat_caller_address(wager.contract_address, bob);
+    wager.fund_wallet(stake);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Join the wager
+    start_cheat_caller_address(wager.contract_address, bob);
+    wager.join_wager(wager_id, claim);
+    stop_cheat_caller_address(wager.contract_address);
+
+    assert(wager.get_wager_participant_claim(wager_id, bob) == claim, 'incorrect claim');
+}
+
+#[test]
+fn test_create_wager_with_claim() {
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Create a wager
+    let stake = 100_u256;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
+    let claim = Claim::Yes;
+
+    let owner = OWNER();
+
+    // check owner claim
+    assert(wager.get_wager_participant_claim(wager_id, owner) == claim, 'incorrect claim');
+}
+
+fn test_get_wager_participants_claim() {
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Create a wager
+    let stake = 100_u256;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
+    let claim = Claim::No;
+
+    let owner = OWNER();
+    let bob = BOB();
+    // Mint tokens for BOB
+    start_cheat_caller_address(strk_dispatcher.contract_address, owner);
+    strk_dispatcher.transfer(bob, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // BOB approves tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, bob);
+    strk_dispatcher.approve(escrow.contract_address, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Fund the wallet of the participant
+    start_cheat_caller_address(wager.contract_address, bob);
+    wager.fund_wallet(stake);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Join the wager
+    start_cheat_caller_address(wager.contract_address, bob);
+    wager.join_wager(wager_id, claim);
+
+    let participants_claim = wager.get_wager_participants_claim(wager_id);
+
+    assert(participants_claim.len() == 2, 'invalid length');
+    let (owner_address, owner_claim) = *participants_claim.at(0);
+    assert(owner_address == owner, 'invalid address');
+    assert(owner_claim == Claim::Yes, 'invalid claim');
+}

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -8,7 +8,7 @@ use snforge_std::{
 };
 
 use contracts::wager::wager::StrkWager;
-use contracts::wager::types::{Mode, Category};
+use contracts::wager::types::{Mode, Category, Claim};
 
 use contracts::escrow::interface::{IEscrowDispatcher, IEscrowDispatcherTrait};
 use contracts::wager::interface::{IStrkWagerDispatcher, IStrkWagerDispatcherTrait};
@@ -106,9 +106,10 @@ pub fn create_wager(
     let terms = "My terms";
     let category = Category::Sports;
     let mode = Mode::HeadToHead;
+    let claim = Claim::Yes;
 
     cheat_caller_address(wager.contract_address, creator, CheatSpan::TargetCalls(1));
-    let wager_id = wager.create_wager(category, title.clone(), terms.clone(), stake, mode);
+    let wager_id = wager.create_wager(category, title.clone(), terms.clone(), stake, mode, claim);
     stop_cheat_caller_address(wager.contract_address);
 
     spy

--- a/contracts/src/wager/interface.cairo
+++ b/contracts/src/wager/interface.cairo
@@ -1,5 +1,5 @@
 use starknet::ContractAddress;
-use contracts::wager::types::{Wager, Category, Mode};
+use contracts::wager::types::{Wager, Category, Mode, Claim};
 
 #[starknet::interface]
 pub trait IStrkWager<TContractState> {
@@ -13,11 +13,15 @@ pub trait IStrkWager<TContractState> {
         title: ByteArray,
         terms: ByteArray,
         stake: u256,
-        mode: Mode
+        mode: Mode,
+        claim: Claim
     ) -> u64;
-    fn join_wager(ref self: TContractState, wager_id: u64);
+    fn join_wager(ref self: TContractState, wager_id: u64, claim: Claim);
     fn get_wager(self: @TContractState, wager_id: u64) -> Wager;
     fn get_wager_participants(self: @TContractState, wager_id: u64) -> Span<ContractAddress>;
+    fn get_wager_participants_claim(
+        self: @TContractState, wager_id: u64
+    ) -> Span<(ContractAddress, Claim)>;
     fn set_escrow_address(ref self: TContractState, new_address: ContractAddress);
     fn get_escrow_address(self: @TContractState) -> ContractAddress;
     fn resolve_wager(ref self: TContractState, wager_id: u64, winner: ContractAddress);

--- a/contracts/src/wager/interface.cairo
+++ b/contracts/src/wager/interface.cairo
@@ -22,6 +22,9 @@ pub trait IStrkWager<TContractState> {
     fn get_wager_participants_claim(
         self: @TContractState, wager_id: u64
     ) -> Span<(ContractAddress, Claim)>;
+    fn get_wager_participant_claim(
+        self: @TContractState, wager_id: u64, participant: ContractAddress
+    ) -> Claim;
     fn set_escrow_address(ref self: TContractState, new_address: ContractAddress);
     fn get_escrow_address(self: @TContractState) -> ContractAddress;
     fn resolve_wager(ref self: TContractState, wager_id: u64, winner: ContractAddress);

--- a/contracts/src/wager/types.cairo
+++ b/contracts/src/wager/types.cairo
@@ -28,7 +28,7 @@ pub enum Mode {
     Group
 }
 
-#[derive(Copy, Drop, Serde, starknet::Store)]
+#[derive(Drop, Copy, Serde, PartialEq, starknet::Store, Default)]
 pub enum Claim {
     #[default]
     No,

--- a/contracts/src/wager/types.cairo
+++ b/contracts/src/wager/types.cairo
@@ -27,3 +27,10 @@ pub enum Mode {
     HeadToHead,
     Group
 }
+
+#[derive(Copy, Drop, Serde, starknet::Store)]
+pub enum Claim {
+    #[default]
+    No,
+    Yes
+}

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -10,7 +10,7 @@ pub mod StrkWager {
     use contracts::escrow::interface::{IEscrowDispatcher, IEscrowDispatcherTrait};
 
     use contracts::wager::interface::IStrkWager;
-    use contracts::wager::types::{Wager, Category, Mode};
+    use contracts::wager::types::{Wager, Category, Mode, Claim};
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin_access::accesscontrol::{AccessControlComponent};
     use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -32,6 +32,9 @@ pub mod StrkWager {
         wager_count: u64,
         wagers: Map<u64, Wager>, // wager_id -> Wager
         wager_participants: Map<u64, Map<u64, ContractAddress>>, // wager_id -> idx -> participants
+        wager_participants_claim: Map<
+            u64, Map<ContractAddress, Claim>
+        >, // wager_id -> participant -> Claim
         wager_participants_count: Map<u64, u64>, // wager_id -> count
         escrow_address: ContractAddress,
         strk_address: ContractAddress,
@@ -52,6 +55,7 @@ pub mod StrkWager {
         #[flat]
         SRC5Event: SRC5Component::Event,
     }
+
 
     #[derive(Drop, starknet::Event)]
     pub struct EscrowAddressEvent {
@@ -131,7 +135,8 @@ pub mod StrkWager {
             title: ByteArray,
             terms: ByteArray,
             stake: u256,
-            mode: Mode
+            mode: Mode,
+            claim: Claim
         ) -> u64 {
             assert(self._has_sufficient_balance(stake), 'Insufficient balance');
 
@@ -155,14 +160,14 @@ pub mod StrkWager {
             let participant_id = self.wager_participants_count.entry(wager_id).read() + 1;
             self.wager_participants.entry(wager_id).entry(participant_id).write(creator);
             self.wager_participants_count.entry(wager_id).write(participant_id);
+            self._submit_claim(wager_id, creator, claim);
 
             self.emit(WagerCreatedEvent { wager_id, category, title, terms, creator, stake, mode });
 
             wager_id
         }
 
-
-        fn join_wager(ref self: ContractState, wager_id: u64) {
+        fn join_wager(ref self: ContractState, wager_id: u64, claim: Claim) {
             let wager = self.get_wager(wager_id);
 
             assert(!wager.creator.is_zero(), 'Wager does not exist');
@@ -180,6 +185,7 @@ pub mod StrkWager {
             let participant_id = self.wager_participants_count.entry(wager_id).read() + 1;
             self.wager_participants.entry(wager_id).entry(participant_id).write(caller);
             self.wager_participants_count.entry(wager_id).write(participant_id);
+            self._submit_claim(wager_id, caller, claim);
 
             self.emit(WagerJoinedEvent { wager_id, participant: caller });
         }
@@ -187,7 +193,6 @@ pub mod StrkWager {
         fn get_wager(self: @ContractState, wager_id: u64) -> Wager {
             self.wagers.entry(wager_id).read()
         }
-
 
         fn get_wager_participants(self: @ContractState, wager_id: u64) -> Span<ContractAddress> {
             let participant_count = self.wager_participants_count.entry(wager_id).read();
@@ -203,9 +208,25 @@ pub mod StrkWager {
             participants.span()
         }
 
+        fn get_wager_participants_claim(
+            self: @ContractState, wager_id: u64
+        ) -> Span<(ContractAddress, Claim)> {
+            let participants = self.get_wager_participants(wager_id);
+            let mut claim_array: Array<(ContractAddress, Claim)> = array![];
+            for i in 1
+                ..participants
+                    .len() {
+                        let participant = *participants.at(i);
+                        let claim = self._get_participant_claim(wager_id, participant);
+                        claim_array.append((participant, claim));
+                    };
+            claim_array.span()
+        }
+
         fn get_escrow_address(self: @ContractState) -> ContractAddress {
             self.escrow_address.read()
         }
+
         fn set_escrow_address(ref self: ContractState, new_address: ContractAddress) {
             self.accesscontrol.assert_only_role(ADMIN_ROLE);
             assert(!new_address.is_zero(), 'Invalid address');
@@ -272,5 +293,17 @@ pub mod StrkWager {
 
         //TODO
         fn _fund_wager(self: @ContractState, wager_id: u64, amount: u256) {}
+
+        fn _submit_claim(
+            self: @ContractState, wager_id: u64, participant: ContractAddress, claim: Claim
+        ) {
+            self.wager_participants_claim.entry(wager_id).entry(participant).write(claim);
+        }
+
+        fn _get_participant_claim(
+            self: @ContractState, wager_id: u64, participant: ContractAddress
+        ) -> Claim {
+            self.wager_participants_claim.entry(wager_id).entry(participant).read()
+        }
     }
 }

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -32,9 +32,10 @@ pub mod StrkWager {
         wager_count: u64,
         wagers: Map<u64, Wager>, // wager_id -> Wager
         wager_participants: Map<u64, Map<u64, ContractAddress>>, // wager_id -> idx -> participants
-        wager_participants_claim: Map<
+        wager_participants_claim: Map::<
             u64, Map<ContractAddress, Claim>
         >, // wager_id -> participant -> Claim
+        claim: Claim,
         wager_participants_count: Map<u64, u64>, // wager_id -> count
         escrow_address: ContractAddress,
         strk_address: ContractAddress,
@@ -223,6 +224,12 @@ pub mod StrkWager {
             claim_array.span()
         }
 
+        fn get_wager_participant_claim(
+            self: @ContractState, wager_id: u64, participant: ContractAddress
+        ) -> Claim {
+            self.wager_participants_claim.entry(wager_id).entry(participant).read()
+        }
+
         fn get_escrow_address(self: @ContractState) -> ContractAddress {
             self.escrow_address.read()
         }
@@ -295,7 +302,7 @@ pub mod StrkWager {
         fn _fund_wager(self: @ContractState, wager_id: u64, amount: u256) {}
 
         fn _submit_claim(
-            self: @ContractState, wager_id: u64, participant: ContractAddress, claim: Claim
+            ref self: ContractState, wager_id: u64, participant: ContractAddress, claim: Claim
         ) {
             self.wager_participants_claim.entry(wager_id).entry(participant).write(claim);
         }


### PR DESCRIPTION
Fixes #75 

## Description

- Added Claim ENUM with fields `No` and `Yes`.
- Added `wager_participant_claim` field to Storage.
- Created internal functions `_submit_claim` and `_get_wager_participant_claim`.
- Created entrypoint `get_wager_participants_claim` that returns an Array (Span) of (ContractAddress, Claim) pair.
- Added claim parameter to `create_wager` and `join_wager` functions.
- Edited the functions to call `_submit_claim`.
- Edited the tests to take the new arguments for the updated functions.