### PR TITLE
Feat: Create Endpoint for Bulk Wager Creation (Admin Only)

### DIFF
--- a/backend/src/wager/controllers/wager.controller.ts
+++ b/backend/src/wager/controllers/wager.controller.ts
@@ -10,12 +10,18 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { WagerService } from '../services/wager.service';
-import { CreateWagerDto, GetWagersQueryDto } from '../dtos/wager.dto';
-import { CreateWagerGuard } from '../guards/wager.guard';
+import {
+  BulkCreateWagerDto,
+  CreateWagerDto,
+  GetWagersQueryDto,
+} from '../dtos/wager.dto';
+import { BulkCreateWagerGuard, CreateWagerGuard } from '../guards/wager.guard';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { SwaggerWagerApiQuery } from '../../common/decorators/swagger.decorator';
 import { PaginationInterceptor } from 'src/common/decorators/pagination.decorator';
 import { paginate } from 'src/common/utils/paginate';
+import { Roles } from 'src/common/decorators/roles.decorator';
+import { Role } from 'src/common/enums/roles.enum';
 
 @ApiBearerAuth('JWT-AUTH')
 @Controller('wager')
@@ -47,5 +53,18 @@ export class WagerController {
   @Get('view/:id')
   findOne(@Param('id') id: string) {
     return this.wagerService.findOneById(id);
+  }
+
+  @Post('bulk-create')
+  @UseGuards(BulkCreateWagerGuard)
+  @Roles(Role.Admin)
+  async bulkCreate(@Body() data: BulkCreateWagerDto, @Req() req: Request) {
+    const userId = req['user'].sub;
+    const wagersWithUser = data.wagers.map((wager) => ({
+      ...wager,
+      createdById: userId,
+    }));
+
+    return this.wagerService.bulkCreateWagers(wagersWithUser);
   }
 }

--- a/backend/src/wager/dtos/wager.dto.ts
+++ b/backend/src/wager/dtos/wager.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import {
   IsNotEmpty,
   IsOptional,
@@ -5,6 +6,8 @@ import {
   IsNumber,
   IsPositive,
   IsEnum,
+  IsArray,
+  ValidateNested,
 } from 'class-validator';
 
 enum WagerStatus {
@@ -61,4 +64,11 @@ export class GetWagersQueryDto {
   @IsOptional()
   @IsString()
   filterType?: 'AND' | 'OR';
+}
+
+export class BulkCreateWagerDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateWagerDto)
+  wagers: CreateWagerDto[];
 }

--- a/backend/src/wager/guards/wager.guard.ts
+++ b/backend/src/wager/guards/wager.guard.ts
@@ -2,11 +2,13 @@ import {
   BadRequestException,
   CanActivate,
   ExecutionContext,
+  forwardRef,
+  Inject,
   Injectable,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { CategoryService } from 'src/category/services/category.service';
-import { CreateWagerDto } from '../dtos/wager.dto';
+import { BulkCreateWagerDto, CreateWagerDto } from '../dtos/wager.dto';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 
@@ -48,5 +50,77 @@ export class CreateWagerGuard implements CanActivate {
       error: 'Bad Request',
       statusCode: 400,
     };
+  }
+}
+
+export class BulkCreateWagerGuard implements CanActivate {
+  constructor(
+    @Inject(forwardRef(() => CategoryService))
+    private readonly categoryService: CategoryService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: Request = context.switchToHttp().getRequest();
+    const bulkDto = plainToInstance(BulkCreateWagerDto, req.body);
+
+    // Validate BulkCreateWagerDto structure
+    const validationErrors = await validate(bulkDto);
+    if (validationErrors.length > 0) {
+      throw new BadRequestException(
+        this.formatValidationErrors(validationErrors),
+      );
+    }
+
+    // Ensure wagers array is not empty
+    if (!bulkDto.wagers || bulkDto.wagers.length === 0) {
+      throw new BadRequestException({
+        message: 'Payload must be a non-empty array of wagers.',
+        error: 'Bad Request',
+        statusCode: 400,
+      });
+    }
+
+    // Validate each wager inside the array
+    const errors = await this.validateWagers(bulkDto.wagers);
+    if (errors.length > 0) {
+      throw new BadRequestException(errors);
+    }
+
+    // Attach the validated DTO to the request
+    req.body = bulkDto;
+
+    return true;
+  }
+
+  private async validateWagers(wagers: any[]): Promise<any[]> {
+    const errors: any[] = [];
+
+    for (const wager of wagers) {
+      const validationResult = await validate(wager);
+      if (validationResult.length > 0) {
+        errors.push(...this.formatValidationErrors(validationResult));
+      }
+
+      // Ensure category exists
+      if (!this.categoryService) {
+        throw new BadRequestException('CategoryService is not available.');
+      }
+
+      const categoryExists = await this.categoryService.findOne(
+        wager.categoryId,
+      );
+      if (!categoryExists) {
+        errors.push(`Category with ID ${wager.categoryId} does not exist.`);
+      }
+    }
+
+    return errors;
+  }
+
+  private formatValidationErrors(errors: any[]) {
+    return errors.map((error) => ({
+      field: error.property,
+      message: Object.values(error.constraints),
+    }));
   }
 }

--- a/backend/src/wager/services/wager.service.spec.ts
+++ b/backend/src/wager/services/wager.service.spec.ts
@@ -83,4 +83,48 @@ describe('WagerService', () => {
       expect(result).toEqual(mockWager);
     });
   });
+
+  describe('bulkCreateWagers', () => {
+    it('should create multiple wagers', async () => {
+      const createWagerDtos: CreateWagerDto[] = [
+        {
+          name: 'Wager 1',
+          description: 'Description 1',
+          categoryId: '1',
+          stakeAmount: 100,
+          createdById: mockWager.createdById,
+        },
+        {
+          name: 'Wager 2',
+          description: 'Description 2',
+          categoryId: '2',
+          stakeAmount: 200,
+          createdById: mockWager.createdById,
+        },
+      ];
+
+      const mockCreatedWagers = createWagerDtos.map((dto, index) => ({
+        id: (index + 1).toString(),
+        ...dto,
+        status: WagerStatus.PENDING,
+        tags: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }));
+
+      prisma.wager.createMany = jest
+        .fn()
+        .mockResolvedValue({ count: createWagerDtos.length });
+      prisma.wager.findMany = jest.fn().mockResolvedValue(mockCreatedWagers);
+
+      const result = await service.bulkCreateWagers(createWagerDtos);
+
+      expect(prisma.wager.createMany).toHaveBeenCalledWith({
+        data: createWagerDtos,
+        skipDuplicates: true,
+      });
+      expect(prisma.wager.findMany).toHaveBeenCalled();
+      expect(result).toEqual(mockCreatedWagers);
+    });
+  });
 });

--- a/backend/src/wager/services/wager.service.ts
+++ b/backend/src/wager/services/wager.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'nestjs-prisma';
 import WagerStatus, { CreateWagerDto } from '../dtos/wager.dto';
 import { Wager } from '@prisma/client';
@@ -72,4 +72,36 @@ export class WagerService {
       },
     });
   }
+
+  async bulkCreateWagers(payload: CreateWagerDto[]) {
+    return this.prisma.$transaction(async (tx) => {
+      const createdWagers = [];
+  
+      for (const wager of payload) {
+        // Check if a wager with the same name already exists
+        const existingWager = await tx.wager.findFirst({
+          where: { name: wager.name },
+        });
+  
+        if (existingWager) {
+          throw new BadRequestException(`Wager with name "${wager.name}" already exists.`);
+        }
+  
+        // Create the wager
+        const newWager = await tx.wager.create({
+          data: {
+            ...wager,
+            hashtags: wager.hashtags
+              ? { connectOrCreate: wager.hashtags.map((name) => ({ where: { name }, create: { name } })) }
+              : undefined,
+          },
+        });
+  
+        createdWagers.push(newWager);
+      }
+  
+      return createdWagers;
+    });
+  }
+  
 }

--- a/backend/src/wager/wager.module.ts
+++ b/backend/src/wager/wager.module.ts
@@ -2,11 +2,12 @@ import { Global, Module } from '@nestjs/common';
 import { WagerService } from './services/wager.service';
 import { WagerController } from './controllers/wager.controller';
 import { CategoryService } from '../category/services/category.service';
+import { JwtService } from '@nestjs/jwt';
 
 @Global()
 @Module({
   controllers: [WagerController],
-  providers: [WagerService, CategoryService],
+  providers: [WagerService, CategoryService, JwtService],
   imports: [],
 })
 export class WagerModule {}


### PR DESCRIPTION
closes #114 

Enhanced the existing wager creation functionality, by adding a service function for creating bulk wager by admin only. I added a dto to validate bulk wager creation, bulk wager creation service, controller, route and added Roles decorator with role enum to define accessibility. and authorisation.

Thanks for reviewing this.
