### PR TITLE
feat#116: Implement wager state management

### DIFF
--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 use starknet::{testing, contract_address_const, get_caller_address};
 
 use contracts::wager::wager::StrkWager;
-use contracts::wager::types::{Category, Mode, Claim};
+use contracts::wager::types::{Category, Mode, Claim, WagerState};
 use contracts::wager::interface::{IStrkWagerDispatcher, IStrkWagerDispatcherTrait};
 use contracts::escrow::interface::IEscrowDispatcherTrait;
 use contracts::tests::utils::{OWNER, ADMIN, ALICE, BOB, setup, create_wager};
@@ -421,7 +421,7 @@ fn test_get_wager_ok() {
     assert!(retrieved_wager.terms == "My terms", "Incorrect terms");
     assert!(retrieved_wager.creator == OWNER(), "Incorrect creator");
     assert!(retrieved_wager.stake == stake, "Incorrect stake");
-    assert!(!retrieved_wager.resolved, "Wager should not be resolved");
+    assert!(retrieved_wager.state != WagerState::Resolved, "Wager should not be resolved");
     assert!(retrieved_wager.mode == Mode::HeadToHead, "Incorrect mode");
 }
 
@@ -690,5 +690,120 @@ fn test_join_wager_if_already_a_participant() {
     start_cheat_caller_address(wager.contract_address, owner);
     wager.join_wager(wager_id, claim);
     wager.join_wager(wager_id, claim);
+    stop_cheat_caller_address(wager.contract_address);
+}
+
+#[test]
+fn test_wager_state_transitions() {
+    // Set up the test environment
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 1. Create a wager and verify Pending state
+    let stake = 1000_u256;
+    let deposit = 2000_u256;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
+
+    let created_wager = wager.get_wager(wager_id);
+    assert!(
+        created_wager.state == WagerState::Pending,
+        "Wager should be in Pending state after creation"
+    );
+
+    // 2. Have another user join the wager and verify Active state
+    let participant = BOB();
+
+    // Fund the participant
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(participant, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Approve escrow to spend tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, participant);
+    strk_dispatcher.approve(escrow.contract_address, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Join the wager
+    start_cheat_caller_address(wager.contract_address, participant);
+    wager.join_wager(wager_id, Claim::Yes);
+    stop_cheat_caller_address(wager.contract_address);
+
+    let active_wager = wager.get_wager(wager_id);
+    assert!(
+        active_wager.state == WagerState::Active, "Wager should be in Active state after joining"
+    );
+
+    // 3. Resolve the wager and verify Resolved state
+    start_cheat_caller_address(wager.contract_address, OWNER());
+    wager.resolve_wager(wager_id, OWNER());
+    stop_cheat_caller_address(wager.contract_address);
+
+    let resolved_wager = wager.get_wager(wager_id);
+    assert!(
+        resolved_wager.state == WagerState::Resolved,
+        "Wager should be in Resolved state after resolution"
+    );
+    assert!(resolved_wager.winner == OWNER(), "Winner should be correctly set");
+}
+
+#[test]
+#[should_panic(expected: ('Wager is already resolved',))]
+fn test_cannot_join_resolved_wager() {
+    // Set up the test environment
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 1. Create a wager
+    let stake = 1000_u256;
+    let deposit = 2000_u256;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
+
+    // 2. Have BOB join the wager
+    let participant = BOB();
+
+    // Fund the participant
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(participant, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Approve escrow to spend tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, participant);
+    strk_dispatcher.approve(escrow.contract_address, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Join the wager
+    start_cheat_caller_address(wager.contract_address, participant);
+    wager.join_wager(wager_id, Claim::Yes);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 3. Resolve the wager
+    start_cheat_caller_address(wager.contract_address, OWNER());
+    wager.resolve_wager(wager_id, OWNER());
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 4. Attempt to have another user join the already resolved wager - should fail
+    let third_participant = ALICE();
+
+    // Fund the third participant
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(third_participant, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Approve escrow to spend tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, third_participant);
+    strk_dispatcher.approve(escrow.contract_address, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Try to join the resolved wager - this should panic
+    start_cheat_caller_address(wager.contract_address, third_participant);
+    wager.join_wager(wager_id, Claim::Yes);
     stop_cheat_caller_address(wager.contract_address);
 }

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -8,7 +8,7 @@ use snforge_std::{
 };
 
 use contracts::wager::wager::StrkWager;
-use contracts::wager::types::{Mode, Category, Claim};
+use contracts::wager::types::{Mode, Category, Claim, WagerState};
 
 use contracts::escrow::interface::{IEscrowDispatcher, IEscrowDispatcherTrait};
 use contracts::wager::interface::{IStrkWagerDispatcher, IStrkWagerDispatcherTrait};
@@ -106,6 +106,7 @@ pub fn create_wager(
     let category = Category::Sports;
     let mode = Mode::HeadToHead;
     let claim = Claim::Yes;
+    let state = WagerState::Pending;
 
     cheat_caller_address(wager.contract_address, creator, CheatSpan::TargetCalls(1));
     let wager_id = wager.create_wager(category, title.clone(), terms.clone(), stake, mode, claim);
@@ -118,7 +119,7 @@ pub fn create_wager(
                     wager.contract_address,
                     StrkWager::Event::WagerCreated(
                         StrkWager::WagerCreatedEvent {
-                            wager_id, category, title, terms, creator, stake, mode,
+                            wager_id, category, title, terms, creator, stake, mode, state
                         }
                     )
                 )

--- a/contracts/src/wager/types.cairo
+++ b/contracts/src/wager/types.cairo
@@ -8,9 +8,9 @@ pub struct Wager {
     pub terms: ByteArray,
     pub creator: ContractAddress,
     pub stake: u256,
-    pub resolved: bool,
     pub winner: ContractAddress,
     pub mode: Mode,
+    pub state: WagerState,
 }
 
 #[derive(Drop, Copy, Serde, PartialEq, starknet::Store, Default)]
@@ -33,4 +33,14 @@ pub enum Claim {
     #[default]
     No,
     Yes
+}
+
+#[derive(Drop, Copy, Serde, PartialEq, starknet::Store, Default)]
+pub enum WagerState {
+    #[default]
+    Pending,
+    Active,
+    VotingPhase,
+    Resolved,
+    Cancelled
 }

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -10,7 +10,7 @@ pub mod StrkWager {
     use contracts::escrow::interface::{IEscrowDispatcher, IEscrowDispatcherTrait};
 
     use contracts::wager::interface::IStrkWager;
-    use contracts::wager::types::{Wager, Category, Mode, Claim};
+    use contracts::wager::types::{Wager, Category, Mode, Claim, WagerState};
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin_access::accesscontrol::{AccessControlComponent};
     use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -74,6 +74,7 @@ pub mod StrkWager {
         pub creator: ContractAddress,
         pub stake: u256,
         pub mode: Mode,
+        pub state: WagerState,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -135,7 +136,7 @@ pub mod StrkWager {
 
             let creator = get_caller_address();
             let wager_id = self.wager_count.read() + 1;
-
+            let state = WagerState::Pending;
             let new_wager = Wager {
                 wager_id,
                 category,
@@ -143,9 +144,9 @@ pub mod StrkWager {
                 terms: terms.clone(),
                 creator,
                 stake,
-                resolved: false,
                 winner: contract_address_const::<0>(),
-                mode
+                mode,
+                state,
             };
 
             self.wagers.entry(wager_id).write(new_wager);
@@ -163,17 +164,22 @@ pub mod StrkWager {
 
             self._fund_wager(wager_id, stake);
 
-            self.emit(WagerCreatedEvent { wager_id, category, title, terms, creator, stake, mode });
+            self
+                .emit(
+                    WagerCreatedEvent {
+                        wager_id, category, title, terms, creator, stake, mode, state
+                    }
+                );
 
             wager_id
         }
 
         fn join_wager(ref self: ContractState, wager_id: u64, claim: Claim) {
-            let wager = self.get_wager(wager_id);
+            let mut wager = self.get_wager(wager_id);
             let caller = get_caller_address();
 
             assert(!wager.creator.is_zero(), 'Wager does not exist');
-            assert(!wager.resolved, 'Wager is already resolved');
+            assert(wager.state != WagerState::Resolved, 'Wager is already resolved');
 
             // Check if caller is already a participant
             assert(!self.is_wager_participant(wager_id, caller), 'Already a participant');
@@ -198,6 +204,9 @@ pub mod StrkWager {
             }
 
             self._fund_wager(wager_id, wager.stake);
+
+            wager.state = WagerState::Active;
+            self.wagers.entry(wager_id).write(wager);
 
             self.emit(WagerJoinedEvent { wager_id, participant: caller });
         }
@@ -243,9 +252,9 @@ pub mod StrkWager {
         //TODO
         fn resolve_wager(ref self: ContractState, wager_id: u64, winner: ContractAddress) {
             let mut wager = self.wagers.entry(wager_id).read();
-            assert(!wager.resolved, 'Wager is already resolved');
+            assert(wager.state != WagerState::Resolved, 'Wager is already resolved');
 
-            wager.resolved = true;
+            wager.state = WagerState::Resolved;
             wager.winner = winner;
 
             self.wagers.entry(wager_id).write(wager);


### PR DESCRIPTION
## Related issue #116 

## PR Description

Hello, this PR implements a formal state management system to track the lifecycle of wagers, as requested in issue #116.

### Changes:

- Added a `WagerState` enum with the following states:
  - `Pending`: Initial state after creation, awaiting participants
  - `Active`: Participants joined, wager is underway
  - `VotingPhase`: Condition end date reached, participants submitting outcome votes
  - `Resolved`: Outcome determined and winner selected
  - `Cancelled`: Wager cancelled by creator or admin

- Added a `state` field to the `Wager` struct to track the current state.

- Implemented state transitions in existing functions:
  - `create_wager`: Initializes state to `Pending`
  - `join_wager`: Transitions from `Pending` to `Active` when a participant joins
  - `resolve_wager`: Transitions to `Resolved` when an outcome is determined

- Removed the redundant `resolved` boolean field from the `Wager` struct in favor of the more expressive state machine.

- Added appropriate state validation to prevent invalid operations, such as joining a resolved wager.

### Tests:

- Added tests to verify correct state transitions throughout a wager's lifecycle
- Added a negative test to confirm that joining a resolved wager correctly fails

All existing tests continue to pass with these changes, maintaining backward compatibility while providing improved validation logic and a clearer representation of a wager's current status.
