### PR TITLE
[FEAT]: Add submit outcome function

### DIFF
--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -844,7 +844,6 @@ fn test_submit_outcome_pass() {
                 )
             ]
         );
-
 }
 
 #[test]
@@ -870,7 +869,6 @@ fn test_submit_outcome_fail_double_submit() {
 
     wager.submit_outcome(wager_id, true);
 }
-
 
 #[test]
 #[should_panic(expected: 'Wager is already resolved')]

--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -848,7 +848,7 @@ fn test_submit_outcome_pass() {
 }
 
 #[test]
-#[should_panic(expected: 'Participatn already submitted')]
+#[should_panic(expected: 'Participant already submitted')]
 fn test_submit_outcome_fail_double_submit() {
     // Deploy contracts
     let (wager, escrow, strk_dispatcher) = setup();
@@ -869,4 +869,110 @@ fn test_submit_outcome_fail_double_submit() {
     wager.submit_outcome(wager_id, true);
 
     wager.submit_outcome(wager_id, true);
+}
+
+
+#[test]
+#[should_panic(expected: 'Wager is already resolved')]
+fn test_submit_outcome_fail_wager_resolved() {
+    // Set up the test environment
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 1. Create a wager
+    let stake = 1000_u256;
+    let deposit = 2000_u256;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
+
+    // 2. Have BOB join the wager
+    let participant = BOB();
+
+    // Fund the participant
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(participant, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Approve escrow to spend tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, participant);
+    strk_dispatcher.approve(escrow.contract_address, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Join the wager
+    start_cheat_caller_address(wager.contract_address, participant);
+    wager.join_wager(wager_id, Claim::Yes);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 3. Resolve the wager
+    start_cheat_caller_address(wager.contract_address, OWNER());
+    wager.resolve_wager(wager_id, OWNER());
+    stop_cheat_caller_address(wager.contract_address);
+
+    // 4. Attempt to have another user join the already resolved wager - should fail
+    let third_participant = ALICE();
+
+    // Fund the third participant
+    start_cheat_caller_address(strk_dispatcher.contract_address, OWNER());
+    strk_dispatcher.transfer(third_participant, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Approve escrow to spend tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, third_participant);
+    strk_dispatcher.approve(escrow.contract_address, deposit);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Try to join the resolved wager - this should panic
+    start_cheat_caller_address(wager.contract_address, third_participant);
+    wager.submit_outcome(wager_id, true);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Not a participant')]
+fn test_submit_outcome_fail_not_a_participant() {
+    let (wager, escrow, strk_dispatcher) = setup();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Create a wager
+    let stake = 100_u256;
+    let claim = Claim::Yes;
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, stake, stake);
+
+    let owner = OWNER();
+    let bob = BOB();
+
+    // Mint tokens for BOB
+    start_cheat_caller_address(strk_dispatcher.contract_address, owner);
+    strk_dispatcher.transfer(bob, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // BOB approves tokens
+    start_cheat_caller_address(strk_dispatcher.contract_address, bob);
+    strk_dispatcher.approve(escrow.contract_address, stake);
+    stop_cheat_caller_address(strk_dispatcher.contract_address);
+
+    // Fund the wallet of the participant
+    start_cheat_caller_address(wager.contract_address, bob);
+    wager.fund_wallet(stake);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Try to submit outcome - should panic
+    start_cheat_caller_address(wager.contract_address, owner);
+    wager.submit_outcome(wager_id, true);
+    stop_cheat_caller_address(wager.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Wager does not exist')]
+fn test_submit_outcome_fail_wager_no_exists() {
+    let (wager, _, _) = setup();
+
+    wager.submit_outcome(1, true);
 }

--- a/contracts/src/tests/test_wager.cairo
+++ b/contracts/src/tests/test_wager.cairo
@@ -692,3 +692,66 @@ fn test_join_wager_if_already_a_participant() {
     wager.join_wager(wager_id, claim);
     stop_cheat_caller_address(wager.contract_address);
 }
+
+#[test]
+fn test_submit_outcome_pass() {
+    // Deploy contracts
+    let (wager, escrow, strk_dispatcher) = setup();
+    let bob = BOB();
+
+    let mut spy = spy_events();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Create a wager
+    let stake = 100_u256;
+    let deposit = 20_u256; // Insufficient deposit
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
+
+    start_cheat_caller_address(wager.contract_address, bob);
+
+    let vote = true;
+    wager.submit_outcome(wager_id, vote);
+
+    assert(wager.has_outcome_submitted(wager_id, bob), 'outcome not registered');
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    wager.contract_address,
+                    StrkWager::Event::OutcomeSubmitted(
+                        StrkWager::OutcomeSubmittedEvent { wager_id, participant: bob, vote }
+                    )
+                )
+            ]
+        );
+
+}
+
+#[test]
+#[should_panic(expected: 'Participatn already submitted')]
+fn test_submit_outcome_fail_double_submit() {
+    // Deploy contracts
+    let (wager, escrow, strk_dispatcher) = setup();
+    let bob = BOB();
+
+    // Configure wager with escrow
+    start_cheat_caller_address(wager.contract_address, ADMIN());
+    wager.set_escrow_address(escrow.contract_address);
+    stop_cheat_caller_address(wager.contract_address);
+
+    // Create a wager
+    let stake = 100_u256;
+    let deposit = 20_u256; // Insufficient deposit
+    let wager_id = create_wager(wager, escrow, strk_dispatcher, deposit, stake);
+
+    start_cheat_caller_address(wager.contract_address, bob);
+
+    wager.submit_outcome(wager_id, true);
+
+    wager.submit_outcome(wager_id, true);
+}

--- a/contracts/src/wager/interface.cairo
+++ b/contracts/src/wager/interface.cairo
@@ -28,5 +28,4 @@ pub trait IStrkWager<TContractState> {
     fn is_wager_participant(self: @TContractState, wager_id: u64, caller: ContractAddress) -> bool;
     fn has_outcome_submitted(self: @TContractState, wager_id: u64, caller: ContractAddress) -> bool;
     fn submit_outcome(ref self: TContractState, wager_id: u64, vote: bool);
-    
 }

--- a/contracts/src/wager/interface.cairo
+++ b/contracts/src/wager/interface.cairo
@@ -26,4 +26,7 @@ pub trait IStrkWager<TContractState> {
     fn get_escrow_address(self: @TContractState) -> ContractAddress;
     fn resolve_wager(ref self: TContractState, wager_id: u64, winner: ContractAddress);
     fn is_wager_participant(self: @TContractState, wager_id: u64, caller: ContractAddress) -> bool;
+    fn has_outcome_submitted(self: @TContractState, wager_id: u64, caller: ContractAddress) -> bool;
+    fn submit_outcome(ref self: TContractState, wager_id: u64, vote: bool);
+    
 }

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -291,7 +291,7 @@ pub mod StrkWager {
             // Check if caller is a participant
             assert(!self.is_wager_participant(wager_id, caller), 'Not a participant');
 
-            assert(!self.has_outcome_submitted(wager_id, caller), 'Participatn already submitted');
+            assert(!self.has_outcome_submitted(wager_id, caller), 'Participant already submitted');
 
             self.wager_outcome_votes.entry((wager_id, caller)).write(vote);
             self.wager_outcome_submitted.entry((wager_id, caller)).write(true);

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -276,13 +276,13 @@ pub mod StrkWager {
             let wager = self.get_wager(wager_id);
             let caller = get_caller_address();
 
-            assert(!wager.creator.is_zero(), 'Wager does not exist');§
+            assert(!wager.creator.is_zero(), 'Wager does not exist');
             assert(!wager.resolved, 'Wager is already resolved');
 
             // Check if caller is a participant
             assert(!self.is_wager_participant(wager_id, caller), 'Not a participant');
 
-            assert(self.has_outcome_submitted(wager_id, caller), 'Participatn already submitted');
+            assert(!self.has_outcome_submitted(wager_id, caller), 'Participatn already submitted');
 
             self.wager_outcome_votes.entry((wager_id, caller)).write(vote);
             self.wager_outcome_submitted.entry((wager_id, caller)).write(true);

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -36,6 +36,8 @@ pub mod StrkWager {
         wager_participants_claim: Map::<
             u64, Map<ContractAddress, Claim>
         >, // wager_id -> participant -> Claim
+        wager_outcome_votes:  Map<(u64, ContractAddress), bool>, // wager_id -> participant -> vote
+        wager_outcome_submitted: Map<(u64, ContractAddress), bool>,  // wager_id -> participant ->  submitted
         claim: Claim,
         wager_participants_count: Map<u64, u64>, // wager_id -> count
         escrow_address: ContractAddress,
@@ -51,7 +53,7 @@ pub mod StrkWager {
     pub enum Event {
         EscrowAddressUpdated: EscrowAddressEvent,
         WagerCreated: WagerCreatedEvent,
-        WagerJoined: WagerJoinedEvent,
+        OutcomeSubmitted: OutcomeSubmittedEvent,
         #[flat]
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
@@ -152,6 +154,7 @@ pub mod StrkWager {
             self.wager_count.write(wager_id);
             let participant_id = self.wager_participants_count.entry(wager_id).read() + 1;
             self.wager_participants.entry(wager_id).entry(participant_id).write(creator);
+            self.wager_outcome_submitted.entry((wager_id, creator)).write(false);
             self.wager_participants_mapping.entry((wager_id, creator)).write(true);
             self.wager_participants_count.entry(wager_id).write(participant_id);
             self._submit_claim(wager_id, creator, claim);
@@ -255,6 +258,26 @@ pub mod StrkWager {
             self: @ContractState, wager_id: u64, caller: ContractAddress
         ) -> bool {
             self.wager_participants_mapping.entry((wager_id, caller)).read()
+        }
+
+        fn has_outcome_submitted(self: @ContractState, wager_id: u64, caller: ContractAddress) -> bool {
+            self.wager_outcome_submitted.entry((wager_id, caller)).read()
+        }
+
+        fn submit_outcome(ref self: ContractState, wager_id: u64, vote: bool) {
+            let wager = self.get_wager(wager_id);
+            let caller = get_caller_address();
+
+            assert(!wager.creator.is_zero(), 'Wager does not exist');§
+            assert(!wager.resolved, 'Wager is already resolved');
+
+            // Check if caller is a participant
+            assert(!self.is_wager_participant(wager_id, caller), 'Not a participant');
+
+            assert(self.has_outcome_submitted(wager_id, caller), 'Participatn already submitted');
+
+            self.wager_outcome_votes.entry((wager_id, caller)).write(vote);
+            self.wager_outcome_submitted.entry((wager_id, caller)).write(true);
         }
     }
 

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -53,6 +53,7 @@ pub mod StrkWager {
     pub enum Event {
         EscrowAddressUpdated: EscrowAddressEvent,
         WagerCreated: WagerCreatedEvent,
+        WagerJoined: WagerJoinedEvent,
         OutcomeSubmitted: OutcomeSubmittedEvent,
         #[flat]
         AccessControlEvent: AccessControlComponent::Event,
@@ -82,6 +83,13 @@ pub mod StrkWager {
     pub struct WagerJoinedEvent {
         pub wager_id: u64,
         pub participant: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct OutcomeSubmittedEvent {
+        pub wager_id: u64,
+        pub participant: ContractAddress,
+        pub vote: bool,
     }
 
     const ADMIN_ROLE: felt252 = selector!("ADMIN_ROLE"); // Unique identifier for the role
@@ -278,6 +286,8 @@ pub mod StrkWager {
 
             self.wager_outcome_votes.entry((wager_id, caller)).write(vote);
             self.wager_outcome_submitted.entry((wager_id, caller)).write(true);
+
+            self.emit(OutcomeSubmittedEvent { wager_id, participant: caller, vote });
         }
     }
 

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -36,8 +36,10 @@ pub mod StrkWager {
         wager_participants_claim: Map::<
             u64, Map<ContractAddress, Claim>
         >, // wager_id -> participant -> Claim
-        wager_outcome_votes:  Map<(u64, ContractAddress), bool>, // wager_id -> participant -> vote
-        wager_outcome_submitted: Map<(u64, ContractAddress), bool>,  // wager_id -> participant ->  submitted
+        wager_outcome_votes: Map<(u64, ContractAddress), bool>, // wager_id -> participant -> vote
+        wager_outcome_submitted: Map<
+            (u64, ContractAddress), bool
+        >, // wager_id -> participant ->  submitted
         claim: Claim,
         wager_participants_count: Map<u64, u64>, // wager_id -> count
         escrow_address: ContractAddress,
@@ -277,7 +279,9 @@ pub mod StrkWager {
             self.wager_participants_mapping.entry((wager_id, caller)).read()
         }
 
-        fn has_outcome_submitted(self: @ContractState, wager_id: u64, caller: ContractAddress) -> bool {
+        fn has_outcome_submitted(
+            self: @ContractState, wager_id: u64, caller: ContractAddress
+        ) -> bool {
             self.wager_outcome_submitted.entry((wager_id, caller)).read()
         }
 

--- a/contracts/src/wager/wager.cairo
+++ b/contracts/src/wager/wager.cairo
@@ -286,7 +286,7 @@ pub mod StrkWager {
             let caller = get_caller_address();
 
             assert(!wager.creator.is_zero(), 'Wager does not exist');
-            assert(!wager.resolved, 'Wager is already resolved');
+            assert(wager.state != WagerState::Resolved, 'Wager is already resolved');
 
             // Check if caller is a participant
             assert(!self.is_wager_participant(wager_id, caller), 'Not a participant');


### PR DESCRIPTION
## Description  
This PR introduces a new function that allows participants to submit an outcome for a wager.  

### Key Features:  
- Closes #108.  
- Enables participants to submit a boolean outcome (`true/false`) for a specific wager.  
- Ensures the caller is a valid participant in the wager.  
- Verifies that the wager exists and has not been resolved.  
- Prevents participants from submitting multiple outcomes.  
- Records the participant's vote in the `wager_outcome_votes` mapping.  
- Marks the participant as having submitted in the `wager_outcome_submitted` mapping.  
- Emits an `OutcomeSubmittedEvent` with relevant details.  
- Adds comprehensive tests to validate functionality.  

## Test results
<img width="940" alt="image" src="https://github.com/user-attachments/assets/bde7ff4d-4e2f-4173-9e99-b80f2ef8e55a" />
